### PR TITLE
Add Uuid and _version to the generated fields

### DIFF
--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -65,13 +65,13 @@ func main() {
 	ctx := context.Background()
 
 	log.Print("\n-- Sending some individual requests...")
-/*
+
 	if dbs, err := list_dbs(ctx, cli); err != nil {
 		log.Fatalln("Ovsdb.List_dbs:", err)
 	} else {
 		log.Printf("Ovsdb.List_dbs result=%v", dbs)
 	}
-*/
+
 	if echo, err := echo(ctx, cli); err != nil {
 		log.Fatalln("Ovsdb.Echo:", err)
 	} else {

--- a/pkg/codegenerator/generator.go
+++ b/pkg/codegenerator/generator.go
@@ -100,6 +100,14 @@ func printStruct(w io.Writer, tableName string, columns []string) error {
 			return err
 		}
 	}
+	// Add UUID and _version
+	if _, err := fmt.Fprintf(w, "\t Version json.Uuid `json:\"_version,omitempty\"`\n"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "\t Uuid json.Uuid `json:\"uuid,omitempty\"`"); err != nil {
+		return err
+	}
+
 	_, err := fmt.Fprintln(w, "}\n")
 	return err
 }

--- a/pkg/json/OVN_Northbound/types.go
+++ b/pkg/json/OVN_Northbound/types.go
@@ -2,100 +2,170 @@ package OVN_Northbound
 
 import "github.com/roytman/ovsdb-etcd/pkg/json"
 
-type Address_Set struct {
-	Name         string            `json:"name,omitempty"`
-	Addresses    []string          `json:"addresses,omitempty"`
+type Meter_Band struct {
+	Burst_size   int64             `json:"burst_size,omitempty"`
 	External_ids map[string]string `json:"external_ids,omitempty"`
+	Action       string            `json:"action,omitempty"`
+	Rate         int64             `json:"rate,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
 }
 
-type Load_Balancer struct {
-	Vips             map[string]string `json:"vips,omitempty"`
-	Protocol         string            `json:"protocol,omitempty"`
-	Health_check     []json.Uuid       `json:"health_check,omitempty"`
-	Ip_port_mappings map[string]string `json:"ip_port_mappings,omitempty"`
-	Selection_fields []string          `json:"selection_fields,omitempty"`
-	Options          map[string]string `json:"options,omitempty"`
-	External_ids     map[string]string `json:"external_ids,omitempty"`
-	Name             string            `json:"name,omitempty"`
-}
-
-type Logical_Router_Port struct {
-	Ipv6_ra_configs  map[string]string `json:"ipv6_ra_configs,omitempty"`
-	Name             string            `json:"name,omitempty"`
-	Ha_chassis_group json.Uuid         `json:"ha_chassis_group,omitempty"`
-	Mac              string            `json:"mac,omitempty"`
-	Enabled          bool              `json:"enabled,omitempty"`
-	Ipv6_prefix      []string          `json:"ipv6_prefix,omitempty"`
-	External_ids     map[string]string `json:"external_ids,omitempty"`
-	Gateway_chassis  []json.Uuid       `json:"gateway_chassis,omitempty"`
-	Options          map[string]string `json:"options,omitempty"`
-	Networks         []string          `json:"networks,omitempty"`
-	Peer             string            `json:"peer,omitempty"`
-}
-
-type Load_Balancer_Health_Check struct {
-	Vip          string            `json:"vip,omitempty"`
-	Options      map[string]string `json:"options,omitempty"`
-	External_ids map[string]string `json:"external_ids,omitempty"`
+type NAT struct {
+	External_mac        string            `json:"external_mac,omitempty"`
+	Logical_ip          string            `json:"logical_ip,omitempty"`
+	Logical_port        string            `json:"logical_port,omitempty"`
+	Allowed_ext_ips     json.Uuid         `json:"allowed_ext_ips,omitempty"`
+	Exempted_ext_ips    json.Uuid         `json:"exempted_ext_ips,omitempty"`
+	External_ids        map[string]string `json:"external_ids,omitempty"`
+	External_ip         string            `json:"external_ip,omitempty"`
+	External_port_range string            `json:"external_port_range,omitempty"`
+	Type                string            `json:"type,omitempty"`
+	Options             map[string]string `json:"options,omitempty"`
+	Version             json.Uuid         `json:"_version,omitempty"`
+	Uuid                json.Uuid         `json:"uuid,omitempty"`
 }
 
 type Connection struct {
+	Target           string            `json:"target,omitempty"`
 	Max_backoff      int64             `json:"max_backoff,omitempty"`
 	Inactivity_probe int64             `json:"inactivity_probe,omitempty"`
 	Other_config     map[string]string `json:"other_config,omitempty"`
 	External_ids     map[string]string `json:"external_ids,omitempty"`
 	Is_connected     bool              `json:"is_connected,omitempty"`
 	Status           map[string]string `json:"status,omitempty"`
-	Target           string            `json:"target,omitempty"`
+	Version          json.Uuid         `json:"_version,omitempty"`
+	Uuid             json.Uuid         `json:"uuid,omitempty"`
 }
 
-type Logical_Switch_Port struct {
-	Tag_request       int64             `json:"tag_request,omitempty"`
-	Dynamic_addresses string            `json:"dynamic_addresses,omitempty"`
-	Up                bool              `json:"up,omitempty"`
-	Dhcpv4_options    json.Uuid         `json:"dhcpv4_options,omitempty"`
-	Addresses         []string          `json:"addresses,omitempty"`
-	Port_security     []string          `json:"port_security,omitempty"`
-	External_ids      map[string]string `json:"external_ids,omitempty"`
-	Type              string            `json:"type,omitempty"`
-	Options           map[string]string `json:"options,omitempty"`
-	Tag               int64             `json:"tag,omitempty"`
-	Dhcpv6_options    json.Uuid         `json:"dhcpv6_options,omitempty"`
-	Ha_chassis_group  json.Uuid         `json:"ha_chassis_group,omitempty"`
-	Name              string            `json:"name,omitempty"`
-	Parent_name       string            `json:"parent_name,omitempty"`
-	Enabled           bool              `json:"enabled,omitempty"`
+type DNS struct {
+	Records      map[string]string `json:"records,omitempty"`
+	External_ids map[string]string `json:"external_ids,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
 }
 
-type SSL struct {
-	Private_key       string            `json:"private_key,omitempty"`
-	Certificate       string            `json:"certificate,omitempty"`
-	Ca_cert           string            `json:"ca_cert,omitempty"`
-	Bootstrap_ca_cert bool              `json:"bootstrap_ca_cert,omitempty"`
-	Ssl_protocols     string            `json:"ssl_protocols,omitempty"`
-	Ssl_ciphers       string            `json:"ssl_ciphers,omitempty"`
-	External_ids      map[string]string `json:"external_ids,omitempty"`
+type NB_Global struct {
+	Sb_cfg           int64             `json:"sb_cfg,omitempty"`
+	Sb_cfg_timestamp int64             `json:"sb_cfg_timestamp,omitempty"`
+	Hv_cfg           int64             `json:"hv_cfg,omitempty"`
+	External_ids     map[string]string `json:"external_ids,omitempty"`
+	Connections      []json.Uuid       `json:"connections,omitempty"`
+	Ssl              json.Uuid         `json:"ssl,omitempty"`
+	Options          map[string]string `json:"options,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Ipsec            bool              `json:"ipsec,omitempty"`
+	Nb_cfg_timestamp int64             `json:"nb_cfg_timestamp,omitempty"`
+	Hv_cfg_timestamp int64             `json:"hv_cfg_timestamp,omitempty"`
+	Nb_cfg           int64             `json:"nb_cfg,omitempty"`
+	Version          json.Uuid         `json:"_version,omitempty"`
+	Uuid             json.Uuid         `json:"uuid,omitempty"`
 }
 
-type NAT struct {
-	External_mac        string            `json:"external_mac,omitempty"`
-	Logical_port        string            `json:"logical_port,omitempty"`
-	Exempted_ext_ips    json.Uuid         `json:"exempted_ext_ips,omitempty"`
-	Options             map[string]string `json:"options,omitempty"`
-	External_ids        map[string]string `json:"external_ids,omitempty"`
-	External_ip         string            `json:"external_ip,omitempty"`
-	External_port_range string            `json:"external_port_range,omitempty"`
-	Logical_ip          string            `json:"logical_ip,omitempty"`
-	Type                string            `json:"type,omitempty"`
-	Allowed_ext_ips     json.Uuid         `json:"allowed_ext_ips,omitempty"`
+type Gateway_Chassis struct {
+	Name         string            `json:"name,omitempty"`
+	Chassis_name string            `json:"chassis_name,omitempty"`
+	Priority     int64             `json:"priority,omitempty"`
+	External_ids map[string]string `json:"external_ids,omitempty"`
+	Options      map[string]string `json:"options,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
+}
+
+type HA_Chassis_Group struct {
+	Name         string            `json:"name,omitempty"`
+	Ha_chassis   []json.Uuid       `json:"ha_chassis,omitempty"`
+	External_ids map[string]string `json:"external_ids,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
+}
+
+type ACL struct {
+	Direction    string            `json:"direction,omitempty"`
+	Match        string            `json:"match,omitempty"`
+	Log          bool              `json:"log,omitempty"`
+	Meter        string            `json:"meter,omitempty"`
+	External_ids map[string]string `json:"external_ids,omitempty"`
+	Name         string            `json:"name,omitempty"`
+	Action       string            `json:"action,omitempty"`
+	Severity     string            `json:"severity,omitempty"`
+	Priority     int64             `json:"priority,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Logical_Router struct {
+	Name          string            `json:"name,omitempty"`
+	Ports         []json.Uuid       `json:"ports,omitempty"`
+	Nat           []json.Uuid       `json:"nat,omitempty"`
+	Options       map[string]string `json:"options,omitempty"`
+	External_ids  map[string]string `json:"external_ids,omitempty"`
+	Static_routes []json.Uuid       `json:"static_routes,omitempty"`
+	Policies      []json.Uuid       `json:"policies,omitempty"`
+	Enabled       bool              `json:"enabled,omitempty"`
+	Load_balancer []json.Uuid       `json:"load_balancer,omitempty"`
+	Version       json.Uuid         `json:"_version,omitempty"`
+	Uuid          json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Logical_Router_Static_Route struct {
+	Ip_prefix    string            `json:"ip_prefix,omitempty"`
+	Policy       string            `json:"policy,omitempty"`
+	Nexthop      string            `json:"nexthop,omitempty"`
+	Output_port  string            `json:"output_port,omitempty"`
+	Options      map[string]string `json:"options,omitempty"`
+	External_ids map[string]string `json:"external_ids,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Forwarding_Group struct {
+	External_ids map[string]string `json:"external_ids,omitempty"`
+	Child_port   []string          `json:"child_port,omitempty"`
+	Name         string            `json:"name,omitempty"`
+	Vip          string            `json:"vip,omitempty"`
+	Vmac         string            `json:"vmac,omitempty"`
+	Liveness     bool              `json:"liveness,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
 }
 
 type Meter struct {
+	External_ids map[string]string `json:"external_ids,omitempty"`
 	Name         string            `json:"name,omitempty"`
 	Unit         string            `json:"unit,omitempty"`
 	Bands        []json.Uuid       `json:"bands,omitempty"`
 	Fair         bool              `json:"fair,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
+}
+
+type HA_Chassis struct {
+	Chassis_name string            `json:"chassis_name,omitempty"`
+	Priority     int64             `json:"priority,omitempty"`
 	External_ids map[string]string `json:"external_ids,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Logical_Switch_Port struct {
+	Enabled           bool              `json:"enabled,omitempty"`
+	Dhcpv4_options    json.Uuid         `json:"dhcpv4_options,omitempty"`
+	Ha_chassis_group  json.Uuid         `json:"ha_chassis_group,omitempty"`
+	Addresses         []string          `json:"addresses,omitempty"`
+	Port_security     []string          `json:"port_security,omitempty"`
+	Options           map[string]string `json:"options,omitempty"`
+	Tag               int64             `json:"tag,omitempty"`
+	Dhcpv6_options    json.Uuid         `json:"dhcpv6_options,omitempty"`
+	Name              string            `json:"name,omitempty"`
+	Type              string            `json:"type,omitempty"`
+	Dynamic_addresses string            `json:"dynamic_addresses,omitempty"`
+	Up                bool              `json:"up,omitempty"`
+	External_ids      map[string]string `json:"external_ids,omitempty"`
+	Parent_name       string            `json:"parent_name,omitempty"`
+	Tag_request       int64             `json:"tag_request,omitempty"`
+	Version           json.Uuid         `json:"_version,omitempty"`
+	Uuid              json.Uuid         `json:"uuid,omitempty"`
 }
 
 type Logical_Router_Policy struct {
@@ -106,127 +176,105 @@ type Logical_Router_Policy struct {
 	Options      map[string]string `json:"options,omitempty"`
 	External_ids map[string]string `json:"external_ids,omitempty"`
 	Priority     int64             `json:"priority,omitempty"`
-}
-
-type Logical_Switch struct {
-	Ports             []json.Uuid       `json:"ports,omitempty"`
-	Acls              []json.Uuid       `json:"acls,omitempty"`
-	Qos_rules         []json.Uuid       `json:"qos_rules,omitempty"`
-	Load_balancer     []json.Uuid       `json:"load_balancer,omitempty"`
-	Forwarding_groups []json.Uuid       `json:"forwarding_groups,omitempty"`
-	Name              string            `json:"name,omitempty"`
-	Dns_records       []json.Uuid       `json:"dns_records,omitempty"`
-	Other_config      map[string]string `json:"other_config,omitempty"`
-	External_ids      map[string]string `json:"external_ids,omitempty"`
-}
-
-type NB_Global struct {
-	Sb_cfg_timestamp int64             `json:"sb_cfg_timestamp,omitempty"`
-	External_ids     map[string]string `json:"external_ids,omitempty"`
-	Connections      []json.Uuid       `json:"connections,omitempty"`
-	Ssl              json.Uuid         `json:"ssl,omitempty"`
-	Name             string            `json:"name,omitempty"`
-	Nb_cfg_timestamp int64             `json:"nb_cfg_timestamp,omitempty"`
-	Sb_cfg           int64             `json:"sb_cfg,omitempty"`
-	Options          map[string]string `json:"options,omitempty"`
-	Ipsec            bool              `json:"ipsec,omitempty"`
-	Nb_cfg           int64             `json:"nb_cfg,omitempty"`
-	Hv_cfg           int64             `json:"hv_cfg,omitempty"`
-	Hv_cfg_timestamp int64             `json:"hv_cfg_timestamp,omitempty"`
-}
-
-type QoS struct {
-	Bandwidth    map[string]int64  `json:"bandwidth,omitempty"`
-	External_ids map[string]string `json:"external_ids,omitempty"`
-	Priority     int64             `json:"priority,omitempty"`
-	Direction    string            `json:"direction,omitempty"`
-	Match        string            `json:"match,omitempty"`
-	Action       map[string]int64  `json:"action,omitempty"`
-}
-
-type HA_Chassis_Group struct {
-	Ha_chassis   []json.Uuid       `json:"ha_chassis,omitempty"`
-	External_ids map[string]string `json:"external_ids,omitempty"`
-	Name         string            `json:"name,omitempty"`
-}
-
-type Meter_Band struct {
-	Action       string            `json:"action,omitempty"`
-	Rate         int64             `json:"rate,omitempty"`
-	Burst_size   int64             `json:"burst_size,omitempty"`
-	External_ids map[string]string `json:"external_ids,omitempty"`
-}
-
-type Port_Group struct {
-	Name         string            `json:"name,omitempty"`
-	Ports        []json.Uuid       `json:"ports,omitempty"`
-	Acls         []json.Uuid       `json:"acls,omitempty"`
-	External_ids map[string]string `json:"external_ids,omitempty"`
-}
-
-type HA_Chassis struct {
-	Chassis_name string            `json:"chassis_name,omitempty"`
-	Priority     int64             `json:"priority,omitempty"`
-	External_ids map[string]string `json:"external_ids,omitempty"`
-}
-
-type ACL struct {
-	Name         string            `json:"name,omitempty"`
-	Match        string            `json:"match,omitempty"`
-	Log          bool              `json:"log,omitempty"`
-	Meter        string            `json:"meter,omitempty"`
-	External_ids map[string]string `json:"external_ids,omitempty"`
-	Priority     int64             `json:"priority,omitempty"`
-	Direction    string            `json:"direction,omitempty"`
-	Action       string            `json:"action,omitempty"`
-	Severity     string            `json:"severity,omitempty"`
-}
-
-type DNS struct {
-	Records      map[string]string `json:"records,omitempty"`
-	External_ids map[string]string `json:"external_ids,omitempty"`
-}
-
-type Gateway_Chassis struct {
-	Priority     int64             `json:"priority,omitempty"`
-	External_ids map[string]string `json:"external_ids,omitempty"`
-	Options      map[string]string `json:"options,omitempty"`
-	Name         string            `json:"name,omitempty"`
-	Chassis_name string            `json:"chassis_name,omitempty"`
-}
-
-type Forwarding_Group struct {
-	Name         string            `json:"name,omitempty"`
-	Vip          string            `json:"vip,omitempty"`
-	Vmac         string            `json:"vmac,omitempty"`
-	Liveness     bool              `json:"liveness,omitempty"`
-	External_ids map[string]string `json:"external_ids,omitempty"`
-	Child_port   []string          `json:"child_port,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
 }
 
 type DHCP_Options struct {
 	Cidr         string            `json:"cidr,omitempty"`
 	Options      map[string]string `json:"options,omitempty"`
 	External_ids map[string]string `json:"external_ids,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
 }
 
-type Logical_Router struct {
-	Policies      []json.Uuid       `json:"policies,omitempty"`
-	Load_balancer []json.Uuid       `json:"load_balancer,omitempty"`
-	Options       map[string]string `json:"options,omitempty"`
-	External_ids  map[string]string `json:"external_ids,omitempty"`
-	Name          string            `json:"name,omitempty"`
-	Ports         []json.Uuid       `json:"ports,omitempty"`
-	Static_routes []json.Uuid       `json:"static_routes,omitempty"`
-	Enabled       bool              `json:"enabled,omitempty"`
-	Nat           []json.Uuid       `json:"nat,omitempty"`
+type SSL struct {
+	Certificate       string            `json:"certificate,omitempty"`
+	Ca_cert           string            `json:"ca_cert,omitempty"`
+	Bootstrap_ca_cert bool              `json:"bootstrap_ca_cert,omitempty"`
+	Ssl_protocols     string            `json:"ssl_protocols,omitempty"`
+	Ssl_ciphers       string            `json:"ssl_ciphers,omitempty"`
+	External_ids      map[string]string `json:"external_ids,omitempty"`
+	Private_key       string            `json:"private_key,omitempty"`
+	Version           json.Uuid         `json:"_version,omitempty"`
+	Uuid              json.Uuid         `json:"uuid,omitempty"`
 }
 
-type Logical_Router_Static_Route struct {
+type Address_Set struct {
+	Name         string            `json:"name,omitempty"`
+	Addresses    []string          `json:"addresses,omitempty"`
 	External_ids map[string]string `json:"external_ids,omitempty"`
-	Ip_prefix    string            `json:"ip_prefix,omitempty"`
-	Policy       string            `json:"policy,omitempty"`
-	Nexthop      string            `json:"nexthop,omitempty"`
-	Output_port  string            `json:"output_port,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Port_Group struct {
+	Acls         []json.Uuid       `json:"acls,omitempty"`
+	External_ids map[string]string `json:"external_ids,omitempty"`
+	Name         string            `json:"name,omitempty"`
+	Ports        []json.Uuid       `json:"ports,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
+}
+
+type QoS struct {
+	Direction    string            `json:"direction,omitempty"`
+	Match        string            `json:"match,omitempty"`
+	Action       map[string]int64  `json:"action,omitempty"`
+	Bandwidth    map[string]int64  `json:"bandwidth,omitempty"`
+	External_ids map[string]string `json:"external_ids,omitempty"`
+	Priority     int64             `json:"priority,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Logical_Router_Port struct {
+	Ipv6_ra_configs  map[string]string `json:"ipv6_ra_configs,omitempty"`
+	Ipv6_prefix      []string          `json:"ipv6_prefix,omitempty"`
+	Gateway_chassis  []json.Uuid       `json:"gateway_chassis,omitempty"`
+	Ha_chassis_group json.Uuid         `json:"ha_chassis_group,omitempty"`
+	Options          map[string]string `json:"options,omitempty"`
+	Mac              string            `json:"mac,omitempty"`
+	Peer             string            `json:"peer,omitempty"`
+	Enabled          bool              `json:"enabled,omitempty"`
+	External_ids     map[string]string `json:"external_ids,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Networks         []string          `json:"networks,omitempty"`
+	Version          json.Uuid         `json:"_version,omitempty"`
+	Uuid             json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Logical_Switch struct {
+	Dns_records       []json.Uuid       `json:"dns_records,omitempty"`
+	Other_config      map[string]string `json:"other_config,omitempty"`
+	Forwarding_groups []json.Uuid       `json:"forwarding_groups,omitempty"`
+	Ports             []json.Uuid       `json:"ports,omitempty"`
+	Acls              []json.Uuid       `json:"acls,omitempty"`
+	Load_balancer     []json.Uuid       `json:"load_balancer,omitempty"`
+	External_ids      map[string]string `json:"external_ids,omitempty"`
+	Name              string            `json:"name,omitempty"`
+	Qos_rules         []json.Uuid       `json:"qos_rules,omitempty"`
+	Version           json.Uuid         `json:"_version,omitempty"`
+	Uuid              json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Load_Balancer struct {
+	Options          map[string]string `json:"options,omitempty"`
+	External_ids     map[string]string `json:"external_ids,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Vips             map[string]string `json:"vips,omitempty"`
+	Protocol         string            `json:"protocol,omitempty"`
+	Health_check     []json.Uuid       `json:"health_check,omitempty"`
+	Ip_port_mappings map[string]string `json:"ip_port_mappings,omitempty"`
+	Selection_fields []string          `json:"selection_fields,omitempty"`
+	Version          json.Uuid         `json:"_version,omitempty"`
+	Uuid             json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Load_Balancer_Health_Check struct {
+	Vip          string            `json:"vip,omitempty"`
 	Options      map[string]string `json:"options,omitempty"`
+	External_ids map[string]string `json:"external_ids,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
 }

--- a/pkg/json/OVN_Southbound/types.go
+++ b/pkg/json/OVN_Southbound/types.go
@@ -2,93 +2,139 @@ package OVN_Southbound
 
 import "github.com/roytman/ovsdb-etcd/pkg/json"
 
-type IP_Multicast struct {
-	Query_interval int64     `json:"query_interval,omitempty"`
-	Seq_no         int64     `json:"seq_no,omitempty"`
-	Querier        bool      `json:"querier,omitempty"`
-	Eth_src        string    `json:"eth_src,omitempty"`
-	Ip6_src        string    `json:"ip6_src,omitempty"`
-	Idle_timeout   int64     `json:"idle_timeout,omitempty"`
-	Query_max_resp int64     `json:"query_max_resp,omitempty"`
-	Datapath       json.Uuid `json:"datapath,omitempty"`
-	Enabled        bool      `json:"enabled,omitempty"`
-	Ip4_src        string    `json:"ip4_src,omitempty"`
-	Table_size     int64     `json:"table_size,omitempty"`
-}
-
-type Meter struct {
-	Unit  string      `json:"unit,omitempty"`
-	Bands []json.Uuid `json:"bands,omitempty"`
-	Name  string      `json:"name,omitempty"`
-}
-
 type Load_Balancer struct {
 	Name         string            `json:"name,omitempty"`
 	Vips         map[string]string `json:"vips,omitempty"`
 	Protocol     string            `json:"protocol,omitempty"`
 	Datapaths    []json.Uuid       `json:"datapaths,omitempty"`
 	External_ids map[string]string `json:"external_ids,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
 }
 
-type Address_Set struct {
-	Name      string   `json:"name,omitempty"`
-	Addresses []string `json:"addresses,omitempty"`
-}
-
-type DNS struct {
-	Records      map[string]string `json:"records,omitempty"`
-	Datapaths    []json.Uuid       `json:"datapaths,omitempty"`
+type HA_Chassis struct {
+	Priority     int64             `json:"priority,omitempty"`
 	External_ids map[string]string `json:"external_ids,omitempty"`
+	Chassis      json.Uuid         `json:"chassis,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
 }
 
-type RBAC_Role struct {
-	Name        string               `json:"name,omitempty"`
-	Permissions map[string]json.Uuid `json:"permissions,omitempty"`
+type Port_Binding struct {
+	Options          map[string]string `json:"options,omitempty"`
+	Chassis          json.Uuid         `json:"chassis,omitempty"`
+	External_ids     map[string]string `json:"external_ids,omitempty"`
+	Gateway_chassis  []json.Uuid       `json:"gateway_chassis,omitempty"`
+	Encap            json.Uuid         `json:"encap,omitempty"`
+	Ha_chassis_group json.Uuid         `json:"ha_chassis_group,omitempty"`
+	Tunnel_key       int64             `json:"tunnel_key,omitempty"`
+	Parent_port      string            `json:"parent_port,omitempty"`
+	Tag              int64             `json:"tag,omitempty"`
+	Virtual_parent   string            `json:"virtual_parent,omitempty"`
+	Mac              []string          `json:"mac,omitempty"`
+	Logical_port     string            `json:"logical_port,omitempty"`
+	Type             string            `json:"type,omitempty"`
+	Datapath         json.Uuid         `json:"datapath,omitempty"`
+	Nat_addresses    []string          `json:"nat_addresses,omitempty"`
+	Version          json.Uuid         `json:"_version,omitempty"`
+	Uuid             json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Datapath_Binding struct {
+	Tunnel_key     int64             `json:"tunnel_key,omitempty"`
+	Load_balancers []json.Uuid       `json:"load_balancers,omitempty"`
+	External_ids   map[string]string `json:"external_ids,omitempty"`
+	Version        json.Uuid         `json:"_version,omitempty"`
+	Uuid           json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Meter struct {
+	Name    string      `json:"name,omitempty"`
+	Unit    string      `json:"unit,omitempty"`
+	Bands   []json.Uuid `json:"bands,omitempty"`
+	Version json.Uuid   `json:"_version,omitempty"`
+	Uuid    json.Uuid   `json:"uuid,omitempty"`
+}
+
+type HA_Chassis_Group struct {
+	Name         string            `json:"name,omitempty"`
+	Ha_chassis   []json.Uuid       `json:"ha_chassis,omitempty"`
+	Ref_chassis  []json.Uuid       `json:"ref_chassis,omitempty"`
+	External_ids map[string]string `json:"external_ids,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Gateway_Chassis struct {
+	Priority     int64             `json:"priority,omitempty"`
+	External_ids map[string]string `json:"external_ids,omitempty"`
+	Options      map[string]string `json:"options,omitempty"`
+	Name         string            `json:"name,omitempty"`
+	Chassis      json.Uuid         `json:"chassis,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Connection struct {
+	Is_connected     bool              `json:"is_connected,omitempty"`
+	Status           map[string]string `json:"status,omitempty"`
+	Other_config     map[string]string `json:"other_config,omitempty"`
+	Max_backoff      int64             `json:"max_backoff,omitempty"`
+	Inactivity_probe int64             `json:"inactivity_probe,omitempty"`
+	Read_only        bool              `json:"read_only,omitempty"`
+	Role             string            `json:"role,omitempty"`
+	External_ids     map[string]string `json:"external_ids,omitempty"`
+	Target           string            `json:"target,omitempty"`
+	Version          json.Uuid         `json:"_version,omitempty"`
+	Uuid             json.Uuid         `json:"uuid,omitempty"`
+}
+
+type DHCPv6_Options struct {
+	Name    string    `json:"name,omitempty"`
+	Code    int64     `json:"code,omitempty"`
+	Type    string    `json:"type,omitempty"`
+	Version json.Uuid `json:"_version,omitempty"`
+	Uuid    json.Uuid `json:"uuid,omitempty"`
 }
 
 type Chassis struct {
+	Transport_zones       []string          `json:"transport_zones,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Hostname              string            `json:"hostname,omitempty"`
 	Encaps                []json.Uuid       `json:"encaps,omitempty"`
 	Vtep_logical_switches []string          `json:"vtep_logical_switches,omitempty"`
 	Nb_cfg                int64             `json:"nb_cfg,omitempty"`
 	External_ids          map[string]string `json:"external_ids,omitempty"`
 	Other_config          map[string]string `json:"other_config,omitempty"`
-	Transport_zones       []string          `json:"transport_zones,omitempty"`
-	Name                  string            `json:"name,omitempty"`
-	Hostname              string            `json:"hostname,omitempty"`
+	Version               json.Uuid         `json:"_version,omitempty"`
+	Uuid                  json.Uuid         `json:"uuid,omitempty"`
 }
 
-type SB_Global struct {
-	Connections  []json.Uuid       `json:"connections,omitempty"`
-	Ssl          json.Uuid         `json:"ssl,omitempty"`
-	Options      map[string]string `json:"options,omitempty"`
-	Ipsec        bool              `json:"ipsec,omitempty"`
-	Nb_cfg       int64             `json:"nb_cfg,omitempty"`
-	External_ids map[string]string `json:"external_ids,omitempty"`
+type Multicast_Group struct {
+	Ports      []json.Uuid `json:"ports,omitempty"`
+	Datapath   json.Uuid   `json:"datapath,omitempty"`
+	Name       string      `json:"name,omitempty"`
+	Tunnel_key int64       `json:"tunnel_key,omitempty"`
+	Version    json.Uuid   `json:"_version,omitempty"`
+	Uuid       json.Uuid   `json:"uuid,omitempty"`
 }
 
-type Service_Monitor struct {
-	Options      map[string]string `json:"options,omitempty"`
-	External_ids map[string]string `json:"external_ids,omitempty"`
-	Ip           string            `json:"ip,omitempty"`
-	Protocol     string            `json:"protocol,omitempty"`
-	Port         int64             `json:"port,omitempty"`
-	Status       string            `json:"status,omitempty"`
-	Logical_port string            `json:"logical_port,omitempty"`
-	Src_mac      string            `json:"src_mac,omitempty"`
-	Src_ip       string            `json:"src_ip,omitempty"`
+type Logical_DP_Group struct {
+	Datapaths []json.Uuid `json:"datapaths,omitempty"`
+	Version   json.Uuid   `json:"_version,omitempty"`
+	Uuid      json.Uuid   `json:"uuid,omitempty"`
 }
 
-type Gateway_Chassis struct {
-	External_ids map[string]string `json:"external_ids,omitempty"`
-	Options      map[string]string `json:"options,omitempty"`
-	Name         string            `json:"name,omitempty"`
-	Chassis      json.Uuid         `json:"chassis,omitempty"`
-	Priority     int64             `json:"priority,omitempty"`
-}
-
-type Port_Group struct {
-	Name  string   `json:"name,omitempty"`
-	Ports []string `json:"ports,omitempty"`
+type SSL struct {
+	External_ids      map[string]string `json:"external_ids,omitempty"`
+	Private_key       string            `json:"private_key,omitempty"`
+	Certificate       string            `json:"certificate,omitempty"`
+	Ca_cert           string            `json:"ca_cert,omitempty"`
+	Bootstrap_ca_cert bool              `json:"bootstrap_ca_cert,omitempty"`
+	Ssl_protocols     string            `json:"ssl_protocols,omitempty"`
+	Ssl_ciphers       string            `json:"ssl_ciphers,omitempty"`
+	Version           json.Uuid         `json:"_version,omitempty"`
+	Uuid              json.Uuid         `json:"uuid,omitempty"`
 }
 
 type MAC_Binding struct {
@@ -96,92 +142,38 @@ type MAC_Binding struct {
 	Ip           string    `json:"ip,omitempty"`
 	Mac          string    `json:"mac,omitempty"`
 	Datapath     json.Uuid `json:"datapath,omitempty"`
-}
-
-type RBAC_Permission struct {
-	Table         string   `json:"table,omitempty"`
-	Authorization []string `json:"authorization,omitempty"`
-	Insert_delete bool     `json:"insert_delete,omitempty"`
-	Update        []string `json:"update,omitempty"`
-}
-
-type Connection struct {
-	Target           string            `json:"target,omitempty"`
-	Inactivity_probe int64             `json:"inactivity_probe,omitempty"`
-	Role             string            `json:"role,omitempty"`
-	External_ids     map[string]string `json:"external_ids,omitempty"`
-	Is_connected     bool              `json:"is_connected,omitempty"`
-	Max_backoff      int64             `json:"max_backoff,omitempty"`
-	Read_only        bool              `json:"read_only,omitempty"`
-	Other_config     map[string]string `json:"other_config,omitempty"`
-	Status           map[string]string `json:"status,omitempty"`
-}
-
-type Meter_Band struct {
-	Action     string `json:"action,omitempty"`
-	Rate       int64  `json:"rate,omitempty"`
-	Burst_size int64  `json:"burst_size,omitempty"`
-}
-
-type IGMP_Group struct {
-	Address  string      `json:"address,omitempty"`
-	Datapath json.Uuid   `json:"datapath,omitempty"`
-	Chassis  json.Uuid   `json:"chassis,omitempty"`
-	Ports    []json.Uuid `json:"ports,omitempty"`
+	Version      json.Uuid `json:"_version,omitempty"`
+	Uuid         json.Uuid `json:"uuid,omitempty"`
 }
 
 type Controller_Event struct {
-	Event_type string            `json:"event_type,omitempty"`
 	Event_info map[string]string `json:"event_info,omitempty"`
 	Chassis    json.Uuid         `json:"chassis,omitempty"`
 	Seq_num    int64             `json:"seq_num,omitempty"`
+	Event_type string            `json:"event_type,omitempty"`
+	Version    json.Uuid         `json:"_version,omitempty"`
+	Uuid       json.Uuid         `json:"uuid,omitempty"`
 }
 
-type Port_Binding struct {
-	Type             string            `json:"type,omitempty"`
-	Options          map[string]string `json:"options,omitempty"`
-	Tag              int64             `json:"tag,omitempty"`
+type Logical_Flow struct {
+	Pipeline         string            `json:"pipeline,omitempty"`
+	Table_id         int64             `json:"table_id,omitempty"`
+	Priority         int64             `json:"priority,omitempty"`
+	Match            string            `json:"match,omitempty"`
+	Actions          string            `json:"actions,omitempty"`
 	External_ids     map[string]string `json:"external_ids,omitempty"`
-	Mac              []string          `json:"mac,omitempty"`
-	Logical_port     string            `json:"logical_port,omitempty"`
-	Gateway_chassis  []json.Uuid       `json:"gateway_chassis,omitempty"`
-	Datapath         json.Uuid         `json:"datapath,omitempty"`
-	Virtual_parent   string            `json:"virtual_parent,omitempty"`
-	Tunnel_key       int64             `json:"tunnel_key,omitempty"`
-	Parent_port      string            `json:"parent_port,omitempty"`
-	Nat_addresses    []string          `json:"nat_addresses,omitempty"`
-	Ha_chassis_group json.Uuid         `json:"ha_chassis_group,omitempty"`
-	Chassis          json.Uuid         `json:"chassis,omitempty"`
-	Encap            json.Uuid         `json:"encap,omitempty"`
+	Logical_datapath json.Uuid         `json:"logical_datapath,omitempty"`
+	Logical_dp_group json.Uuid         `json:"logical_dp_group,omitempty"`
+	Version          json.Uuid         `json:"_version,omitempty"`
+	Uuid             json.Uuid         `json:"uuid,omitempty"`
 }
 
-type DHCPv6_Options struct {
-	Name string `json:"name,omitempty"`
-	Code int64  `json:"code,omitempty"`
-	Type string `json:"type,omitempty"`
-}
-
-type Datapath_Binding struct {
-	Tunnel_key     int64             `json:"tunnel_key,omitempty"`
-	Load_balancers []json.Uuid       `json:"load_balancers,omitempty"`
-	External_ids   map[string]string `json:"external_ids,omitempty"`
-}
-
-type Logical_DP_Group struct {
-	Datapaths []json.Uuid `json:"datapaths,omitempty"`
-}
-
-type HA_Chassis struct {
-	Chassis      json.Uuid         `json:"chassis,omitempty"`
-	Priority     int64             `json:"priority,omitempty"`
+type DNS struct {
+	Datapaths    []json.Uuid       `json:"datapaths,omitempty"`
 	External_ids map[string]string `json:"external_ids,omitempty"`
-}
-
-type Multicast_Group struct {
-	Datapath   json.Uuid   `json:"datapath,omitempty"`
-	Name       string      `json:"name,omitempty"`
-	Tunnel_key int64       `json:"tunnel_key,omitempty"`
-	Ports      []json.Uuid `json:"ports,omitempty"`
+	Records      map[string]string `json:"records,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
 }
 
 type Encap struct {
@@ -189,46 +181,112 @@ type Encap struct {
 	Options      map[string]string `json:"options,omitempty"`
 	Ip           string            `json:"ip,omitempty"`
 	Chassis_name string            `json:"chassis_name,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
 }
 
-type Logical_Flow struct {
-	Logical_datapath json.Uuid         `json:"logical_datapath,omitempty"`
-	Logical_dp_group json.Uuid         `json:"logical_dp_group,omitempty"`
-	Pipeline         string            `json:"pipeline,omitempty"`
-	Table_id         int64             `json:"table_id,omitempty"`
-	Priority         int64             `json:"priority,omitempty"`
-	Match            string            `json:"match,omitempty"`
-	Actions          string            `json:"actions,omitempty"`
-	External_ids     map[string]string `json:"external_ids,omitempty"`
+type Address_Set struct {
+	Name      string    `json:"name,omitempty"`
+	Addresses []string  `json:"addresses,omitempty"`
+	Version   json.Uuid `json:"_version,omitempty"`
+	Uuid      json.Uuid `json:"uuid,omitempty"`
 }
 
-type SSL struct {
-	Ssl_ciphers       string            `json:"ssl_ciphers,omitempty"`
-	External_ids      map[string]string `json:"external_ids,omitempty"`
-	Private_key       string            `json:"private_key,omitempty"`
-	Certificate       string            `json:"certificate,omitempty"`
-	Ca_cert           string            `json:"ca_cert,omitempty"`
-	Bootstrap_ca_cert bool              `json:"bootstrap_ca_cert,omitempty"`
-	Ssl_protocols     string            `json:"ssl_protocols,omitempty"`
-}
-
-type HA_Chassis_Group struct {
-	Ha_chassis   []json.Uuid       `json:"ha_chassis,omitempty"`
-	Ref_chassis  []json.Uuid       `json:"ref_chassis,omitempty"`
+type Service_Monitor struct {
+	Src_ip       string            `json:"src_ip,omitempty"`
 	External_ids map[string]string `json:"external_ids,omitempty"`
-	Name         string            `json:"name,omitempty"`
+	Ip           string            `json:"ip,omitempty"`
+	Protocol     string            `json:"protocol,omitempty"`
+	Logical_port string            `json:"logical_port,omitempty"`
+	Options      map[string]string `json:"options,omitempty"`
+	Port         int64             `json:"port,omitempty"`
+	Src_mac      string            `json:"src_mac,omitempty"`
+	Status       string            `json:"status,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
+}
+
+type IP_Multicast struct {
+	Query_max_resp int64     `json:"query_max_resp,omitempty"`
+	Datapath       json.Uuid `json:"datapath,omitempty"`
+	Enabled        bool      `json:"enabled,omitempty"`
+	Querier        bool      `json:"querier,omitempty"`
+	Eth_src        string    `json:"eth_src,omitempty"`
+	Idle_timeout   int64     `json:"idle_timeout,omitempty"`
+	Ip4_src        string    `json:"ip4_src,omitempty"`
+	Ip6_src        string    `json:"ip6_src,omitempty"`
+	Table_size     int64     `json:"table_size,omitempty"`
+	Query_interval int64     `json:"query_interval,omitempty"`
+	Seq_no         int64     `json:"seq_no,omitempty"`
+	Version        json.Uuid `json:"_version,omitempty"`
+	Uuid           json.Uuid `json:"uuid,omitempty"`
+}
+
+type Port_Group struct {
+	Name    string    `json:"name,omitempty"`
+	Ports   []string  `json:"ports,omitempty"`
+	Version json.Uuid `json:"_version,omitempty"`
+	Uuid    json.Uuid `json:"uuid,omitempty"`
 }
 
 type Chassis_Private struct {
-	Name             string            `json:"name,omitempty"`
 	Chassis          json.Uuid         `json:"chassis,omitempty"`
 	Nb_cfg           int64             `json:"nb_cfg,omitempty"`
 	Nb_cfg_timestamp int64             `json:"nb_cfg_timestamp,omitempty"`
 	External_ids     map[string]string `json:"external_ids,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Version          json.Uuid         `json:"_version,omitempty"`
+	Uuid             json.Uuid         `json:"uuid,omitempty"`
+}
+
+type IGMP_Group struct {
+	Address  string      `json:"address,omitempty"`
+	Datapath json.Uuid   `json:"datapath,omitempty"`
+	Chassis  json.Uuid   `json:"chassis,omitempty"`
+	Ports    []json.Uuid `json:"ports,omitempty"`
+	Version  json.Uuid   `json:"_version,omitempty"`
+	Uuid     json.Uuid   `json:"uuid,omitempty"`
+}
+
+type RBAC_Role struct {
+	Name        string               `json:"name,omitempty"`
+	Permissions map[string]json.Uuid `json:"permissions,omitempty"`
+	Version     json.Uuid            `json:"_version,omitempty"`
+	Uuid        json.Uuid            `json:"uuid,omitempty"`
+}
+
+type SB_Global struct {
+	External_ids map[string]string `json:"external_ids,omitempty"`
+	Connections  []json.Uuid       `json:"connections,omitempty"`
+	Ssl          json.Uuid         `json:"ssl,omitempty"`
+	Options      map[string]string `json:"options,omitempty"`
+	Ipsec        bool              `json:"ipsec,omitempty"`
+	Nb_cfg       int64             `json:"nb_cfg,omitempty"`
+	Version      json.Uuid         `json:"_version,omitempty"`
+	Uuid         json.Uuid         `json:"uuid,omitempty"`
+}
+
+type Meter_Band struct {
+	Action     string    `json:"action,omitempty"`
+	Rate       int64     `json:"rate,omitempty"`
+	Burst_size int64     `json:"burst_size,omitempty"`
+	Version    json.Uuid `json:"_version,omitempty"`
+	Uuid       json.Uuid `json:"uuid,omitempty"`
 }
 
 type DHCP_Options struct {
-	Name string `json:"name,omitempty"`
-	Code int64  `json:"code,omitempty"`
-	Type string `json:"type,omitempty"`
+	Code    int64     `json:"code,omitempty"`
+	Type    string    `json:"type,omitempty"`
+	Name    string    `json:"name,omitempty"`
+	Version json.Uuid `json:"_version,omitempty"`
+	Uuid    json.Uuid `json:"uuid,omitempty"`
+}
+
+type RBAC_Permission struct {
+	Insert_delete bool      `json:"insert_delete,omitempty"`
+	Update        []string  `json:"update,omitempty"`
+	Table         string    `json:"table,omitempty"`
+	Authorization []string  `json:"authorization,omitempty"`
+	Version       json.Uuid `json:"_version,omitempty"`
+	Uuid          json.Uuid `json:"uuid,omitempty"`
 }

--- a/pkg/json/_Server/types.go
+++ b/pkg/json/_Server/types.go
@@ -3,12 +3,14 @@ package _Server
 import "github.com/roytman/ovsdb-etcd/pkg/json"
 
 type Database struct {
+	Model     string    `json:"model,omitempty"`
+	Connected bool      `json:"connected,omitempty"`
+	Leader    bool      `json:"leader,omitempty"`
 	Schema    string    `json:"schema,omitempty"`
 	Cid       json.Uuid `json:"cid,omitempty"`
 	Sid       json.Uuid `json:"sid,omitempty"`
 	Index     int64     `json:"index,omitempty"`
 	Name      string    `json:"name,omitempty"`
-	Model     string    `json:"model,omitempty"`
-	Connected bool      `json:"connected,omitempty"`
-	Leader    bool      `json:"leader,omitempty"`
+	Version   json.Uuid `json:"_version,omitempty"`
+	Uuid      json.Uuid `json:"uuid,omitempty"`
 }

--- a/pkg/json/types.go
+++ b/pkg/json/types.go
@@ -31,3 +31,7 @@ type Delete struct {
 type Modify struct {
 	Modify interface{} `json:"modify"`
 }
+
+func (uuid Uuid) String() string {
+	return string(uuid)
+}

--- a/pkg/ovsdb/ovsdb.go
+++ b/pkg/ovsdb/ovsdb.go
@@ -42,8 +42,16 @@ type TransactionResponse struct {
 //   	"id": same "id" as request
 func (s *ServOVSDB) List_dbs(ctx context.Context, param interface{}) ([]string, error) {
 	// fmt.Printf("List_dbs param %T %v\n", param, param)
-	// TODO remove hardcoded list of DBs
-	return []string{"_Server", "OVN_Northbound"}, nil
+	resp, err := s.dbServer.GetData("ovsdb/_Server/Database/", true)
+	if err != nil {
+		return nil, err
+	}
+	dbs := []string{}
+	for _, kv := range resp.Kvs {
+		slices := strings.Split(string(kv.Key), "/")
+		dbs = append(dbs, slices[len(slices) - 1])
+	}
+	return dbs, nil
 }
 
 // This operation retrieves a <database-schema> that describes hosted database <db-name>.
@@ -256,7 +264,7 @@ func (s *ServOVSDB) Unlock(ctx context.Context, param interface{}) (interface{},
 func (s *ServOVSDB) Monitor_cond(ctx context.Context, param []interface{}) (interface{}, error) {
 	fmt.Printf("Monitor_cond %T %+v\n", param, param)
 
-	resp, err := s.dbServer.GetData("ovsdb/" + param[0].(string))
+	resp, err := s.dbServer.GetData("ovsdb/" + param[0].(string), false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add technical columns (uuid, _version) to the generated types.

Implement list_dbs based on the etcd data, instead of the hard coded. 

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>